### PR TITLE
Fix HTTP response MIME Type

### DIFF
--- a/src/http/Response.php
+++ b/src/http/Response.php
@@ -35,11 +35,11 @@ class Response
      * @var array the formatters that are supported by default
      */
     public $contentTypes = [
-        self::FORMAT_RAW => 'text/plain;',
-        self::FORMAT_HTML => 'text/html;',
-        self::FORMAT_JSON => 'application/json;', // RFC 4627
-        self::FORMAT_JSONP => 'application/javascript;', // RFC 4329
-        self::FORMAT_XML => 'application/xml;', // RFC 2376
+        self::FORMAT_RAW => 'text/plain',
+        self::FORMAT_HTML => 'text/html',
+        self::FORMAT_JSON => 'application/json', // RFC 4627
+        self::FORMAT_JSONP => 'application/javascript', // RFC 4329
+        self::FORMAT_XML => 'application/xml', // RFC 2376
     ];
     /**
      * @var string the response format. This determines how to convert [[data]] into [[content]]


### PR DESCRIPTION
MIME Type 句尾不用分號，多了會導致無法正確判讀

[官方手冊](https://codeigniter.com/userguide3/libraries/output.html#CI_Output::set_content_type)